### PR TITLE
Added message to disallow 1 player games.

### DIFF
--- a/mantis.py
+++ b/mantis.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     typedPrint("Lets set up the game!")
     nPlayers = int(typedInput("How many people will be playing? ", 2))
     while nPlayers < 2:
-        print("\nSorry, you need at least 2 people to play the game.")
+        print("Sorry, you need at least 2 people to play the game.\n")
         nPlayers = int(typedInput("How many people will be playing? ", 2))
     print()
 

--- a/mantis.py
+++ b/mantis.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
                 opponents = [pn for pn, p in players.items()]
                 opponents.remove(player.name)
                 if len(opponents) == 1:
-                    opponent = opponent
+                    opponent = opponents[0]
                 else:
                     opponent = input("From who? ")
                     while opponent not in opponents:

--- a/mantis.py
+++ b/mantis.py
@@ -170,9 +170,12 @@ if __name__ == "__main__":
             if choice == 'STEAL':
                 opponents = [pn for pn, p in players.items()]
                 opponents.remove(player.name)
-                opponent = input("From who? ")
-                while opponent not in opponents:
+                if len(opponents) == 1:
+                    opponent = opponent
+                else:
                     opponent = input("From who? ")
+                    while opponent not in opponents:
+                        opponent = input("From who? ")
 
                 drawnCard.showFront()
                 player.steal(drawnCard, players[opponent])

--- a/mantis.py
+++ b/mantis.py
@@ -117,6 +117,9 @@ if __name__ == "__main__":
     # Configure the game ----------------------------------------
     typedPrint("Lets set up the game!")
     nPlayers = int(typedInput("How many people will be playing? ", 2))
+    while nPlayers < 2:
+        print("\nSorry, you need at least 2 people to play the game.")
+        nPlayers = int(typedInput("How many people will be playing? ", 2))
     print()
 
     players = {}


### PR DESCRIPTION
I got stuck in a 1 player game after choosing "steal" and there was no one to steal from, so I was in an eternal loop of "From who?" Now you will get a message and will have to re-enter number of players if you enter something less than 2. You might want to also add a maximum, but probably a less common problem. I wasn't sure how you'd like the typeity things so I just made it a print line. 

Also added more efficient 2 player game, no need to type name of opponent if only one opponent.